### PR TITLE
Support `search` for ruby less than 2.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fakerbot (0.4.1)
+    fakerbot (0.4.2)
       faker
       pastel (~> 0.7.2)
       thor (~> 0.20.0)

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'fakerbot'

--- a/bin/fakerbot
+++ b/bin/fakerbot
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 lib_path = File.expand_path('../lib', __dir__)
-$:.unshift(lib_path) if !$:.include?(lib_path)
+$LOAD_PATH.unshift(lib_path) unless $LOAD_PATH.include?(lib_path)
 require 'fakerbot'
 
 Signal.trap('INT') do

--- a/lib/fakerbot.rb
+++ b/lib/fakerbot.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require_relative 'fakerbot/cli'

--- a/lib/fakerbot/reflector.rb
+++ b/lib/fakerbot/reflector.rb
@@ -60,7 +60,7 @@ module FakerBot
     def search_descendants_matching_query
       faker_descendants.each do |faker|
         methods = faker.my_singleton_methods
-        matching = methods.select { |m| m.match?(/#{query}/i) }
+        matching = methods.select { |m| m.match(/#{query}/i) }
         store(faker, matching)
       end
     end

--- a/lib/fakerbot/renderer.rb
+++ b/lib/fakerbot/renderer.rb
@@ -68,7 +68,7 @@ module FakerBot
 
     def verbose_output(method, const, arr)
       fake, message = faker_method(method, const)
-      arr << crayon.dim.white("=> #{fake.to_s}") << crayon.dim.magenta.bold("#{message}")
+      arr << crayon.dim.white("=> #{fake}") << crayon.dim.magenta.bold(message.to_s)
     end
 
     def faker_method(method, const)
@@ -78,7 +78,7 @@ module FakerBot
     end
 
     def ensure_method_is_supported(method, const)
-      const.respond_to?(:"_deprecated_#{method.to_s}") ? ' ( WILL BE DEPRECATED )' : ''
+      const.respond_to?(:"_deprecated_#{method}") ? ' ( WILL BE DEPRECATED )' : ''
     end
   end
 end

--- a/lib/fakerbot/version.rb
+++ b/lib/fakerbot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FakerBot
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
 end

--- a/lib/fakerbot/version.rb
+++ b/lib/fakerbot/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FakerBot
-  VERSION = '0.4.1'.freeze
+  VERSION = '0.4.1'
 end

--- a/spec/integration/list_spec.rb
+++ b/spec/integration/list_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe '`fakerbot list` command', type: :cli do
         -v, [--verbose], [--no-verbose]            # Include sample Faker output
 
       List all Faker constants
-      OUT
+    OUT
 
     expect(output).to match(expected_output)
   end

--- a/spec/integration/search_spec.rb
+++ b/spec/integration/search_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe '`fakerbot search` command', type: :cli do
         -v, [--verbose], [--no-verbose]            # Include sample Faker output
 
       Search Faker method(s)
-      OUT
+    OUT
     expect(output).to match(expected_output)
   end
 


### PR DESCRIPTION
1. Switching to the `Symbol#match` because of missing `Symbol#match?` method in older Ruby versions
( http://ruby-doc.org/core-2.3.7/Symbol.html#method-i-match ),
2. Very important (not really) cosmetic changes, like `frozen_string_literal`.
What do you think, @akabiru ?