### PR TITLE
Improve search functionality

### DIFF
--- a/lib/fakerbot/reflector.rb
+++ b/lib/fakerbot/reflector.rb
@@ -60,9 +60,13 @@ module FakerBot
     def search_descendants_matching_query
       faker_descendants.each do |faker|
         methods = faker.my_singleton_methods
-        matching = methods.select { |m| m.match(/#{query}/i) }
+        matching = methods.select { |m| method_matches_query?(m) }
         store(faker, matching)
       end
+    end
+
+    def method_matches_query?(method)
+      method.match(/#{query}/i)
     end
 
     def store(descendant, methods)

--- a/lib/fakerbot/reflector.rb
+++ b/lib/fakerbot/reflector.rb
@@ -60,13 +60,14 @@ module FakerBot
     def search_descendants_matching_query
       faker_descendants.each do |faker|
         methods = faker.my_singleton_methods
-        matching = methods.select { |m| method_matches_query?(m) }
+        matching = methods.select { |m| query_matches?(m.to_s) }
         store(faker, matching)
       end
     end
 
-    def method_matches_query?(method)
-      method.match(/#{query}/i)
+    def query_matches?(method_name)
+      method_name_parts = method_name.split(/_/).reject(&:empty?)
+      query.match(/#{method_name_parts.join('|')}/)
     end
 
     def store(descendant, methods)

--- a/spec/fakerbot/reflector_spec.rb
+++ b/spec/fakerbot/reflector_spec.rb
@@ -3,10 +3,10 @@ RSpec.describe FakerBot::Reflector do
 
   describe '.find' do
     context 'when a match is found' do
-      let(:result) { reflector.find('name') }
+      let(:result) { reflector.find('firstname') }
 
       it 'it returns the list of matches' do
-        expect(result[Faker::Name]).to include(:name)
+        expect(result[Faker::Name]).to include(:first_name)
         expect(result).to be_a(Hash)
       end
     end

--- a/spec/integration/search_spec.rb
+++ b/spec/integration/search_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe '`fakerbot search` command', type: :cli do
 
   context 'when search query does not exist' do
     it 'returns a not found message' do
-      output = `fakerbot search asdasdhk`
+      output = `fakerbot search foobar`
       expect(output).to match(/Sorry, we couldn't find a match/)
     end
   end

--- a/spec/unit/search_spec.rb
+++ b/spec/unit/search_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe FakerBot::Commands::Search do
 
   context 'when query object does not exist' do
     before do
-      command.execute('hasjdhaksjd', output: output)
+      command.execute('foobar', output: output)
     end
 
     it 'returns nil' do


### PR DESCRIPTION
## Description 📝 
This attempts to improve the search functionality for finding related methods by expanding on the existing Regex approach. Tests are updated to account for the new matching behavior (first using the example from the related issue, while fixing others in the `unit`/`integration` search spec that were matching on the `as` part of the given query to items from `Faker::Shakespeare`)

## Considerations 🤔 
No additional dependencies are added here, and Ruby support for the approach covers all maintained versions. However by extracting the matching out of `search_descendants_matching_query`, this can be easily extended to consider different approaches to matching (ie. using another library)

An assumption here is made around method names - specifically that they would be following the [Ruby style guide](https://github.com/rubocop-hq/ruby-style-guide#naming) around naming (ie. using `snake_case`)

## Context 🔗 
Closes https://github.com/akabiru/fakerbot/issues/13

🎃 This was identified as a part of [`#hacktoberfest`](https://hacktoberfest.digitalocean.com/), I don't have personal experience using this library (outside of this PR) so there may be considerations that aren't quite accounted for here (feedback welcome)
