### PR TITLE
Skip Gem::Deprecate Warnings; The CLI handles that

### DIFF
--- a/lib/fakerbot/cli.rb
+++ b/lib/fakerbot/cli.rb
@@ -9,6 +9,8 @@ require 'fakerbot/commands/search'
 module FakerBot
   class CLI < Thor
     Error = Class.new(StandardError)
+    # Do not print depracation warnings; the CLI will do that
+    Gem::Deprecate.skip = true
 
     desc 'version', 'fakerbot version'
     def version

--- a/lib/fakerbot/renderer.rb
+++ b/lib/fakerbot/renderer.rb
@@ -15,7 +15,7 @@ module FakerBot
 
     def initialize(hash, options, output)
       @hash = hash
-      @options = options.deep_symbolize_keys
+      @options = options
       @output = output
       @crayon = Pastel.new(enabled: output.tty?)
       @pager = TTY::Pager.new(command: 'less -R')
@@ -70,7 +70,7 @@ module FakerBot
     end
 
     def verbose?
-      options[:verbose] == true
+      options[:verbose]
     end
 
     def verbose_output(method, const, arr)

--- a/spec/fakerbot/renderer_spec.rb
+++ b/spec/fakerbot/renderer_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe FakerBot::Renderer do
     context 'when the verbose option is enabled' do
       it 'renders methods with data' do
         hash = { MockFaker::Foo => [:bar] }
-        options = { 'verbose' => true }
+        options = { verbose: true }
         output = StringIO.new
 
         renderer = described_class.new(hash, options, output)
@@ -65,7 +65,7 @@ RSpec.describe FakerBot::Renderer do
     context 'when the verbose option is disabled' do
       it 'renders methods only' do
         hash = { MockFaker::Foo => [:bar] }
-        options = { 'verbose' => false }
+        options = { verbose: false }
         output = StringIO.new
 
         renderer = described_class.new(hash, options, output)


### PR DESCRIPTION
### Description

When running a `fakerbot` command in verbose mode e.g. `fakerbot list -v` fakerbot actually invokes fakers methods; even ones with deprecation warnings.

When this happens faker will by default print the deprecation warnings. We don't really want that as the CLI is already showing deprecation warnings as handled in #10 
_Sample_

![screenshot 2019-01-18 at 10 35 16](https://user-images.githubusercontent.com/17295175/51372005-d21a3080-1b0c-11e9-8556-76768dc89ddf.jpg)


### Screenshots

```
fakerbot list -v
```
![screenshot 2019-01-18 at 10 30 11](https://user-images.githubusercontent.com/17295175/51371948-ad25bd80-1b0c-11e9-849f-a37b8d1108bb.jpg)

![screenshot 2019-01-18 at 10 30 16](https://user-images.githubusercontent.com/17295175/51371947-ad25bd80-1b0c-11e9-943e-d65d7f45fa74.jpg)