### PR TITLE
release v0.4.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fakerbot (0.4.3)
+    fakerbot (0.4.4)
       faker
       pastel (~> 0.7.2)
       thor (~> 0.20.0)
@@ -13,7 +13,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.2)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.4)
     coveralls (0.7.1)
       multi_json (~> 1.3)
       rest-client
@@ -27,6 +27,11 @@ GEM
     equatable (0.5.0)
     faker (1.9.1)
       i18n (>= 0.7)
+      pastel (~> 0.7.2)
+      thor (~> 0.20.0)
+      tty-pager (~> 0.12.0)
+      tty-screen (~> 0.6.5)
+      tty-tree (~> 0.2.0)
     ffi (1.9.25)
     formatador (0.2.5)
     guard (2.15.0)
@@ -45,7 +50,7 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (1.1.0)
+    i18n (1.5.2)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     listen (3.1.5)
@@ -107,17 +112,17 @@ GEM
     thor (0.20.0)
     tins (1.16.3)
     tty-color (0.4.3)
-    tty-pager (0.11.0)
-      strings (~> 0.1.0)
-      tty-screen (~> 0.6.4)
-      tty-which (~> 0.3.0)
+    tty-pager (0.12.0)
+      strings (~> 0.1.4)
+      tty-screen (~> 0.6)
+      tty-which (~> 0.4)
     tty-screen (0.6.5)
     tty-tree (0.2.0)
-    tty-which (0.3.0)
+    tty-which (0.4.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    unicode-display_width (1.4.0)
+    unicode-display_width (1.4.1)
     unicode_utils (1.4.0)
 
 PLATFORMS
@@ -134,4 +139,4 @@ DEPENDENCIES
   simplecov (~> 0.12)
 
 BUNDLED WITH
-   1.16.5
+   1.17.3

--- a/lib/fakerbot/version.rb
+++ b/lib/fakerbot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FakerBot
-  VERSION = '0.4.3'
+  VERSION = '0.4.4'
 end


### PR DESCRIPTION
- Silence default `Gem::Deprecate` warning output