### PR TITLE
Skip Faker Deprecation Warnings; The CLI handles that - II

### DIFF
--- a/lib/faker/bot.rb
+++ b/lib/faker/bot.rb
@@ -10,42 +10,40 @@ module Faker
   module Bot
     class Base < Thor
       Error = Class.new(StandardError)
-      # Skip default deprecation warning output; the Bot will display that.
-      Gem::Deprecate.skip_during do
-        desc 'version', 'Faker version'
-        def version
-          puts "v#{Faker::Bot::VERSION}"
-        end
-        map %w[--version -v] => :version
 
-        desc 'list', 'List all Faker constants'
-        method_option :help, aliases: '-h', type: :boolean,
-                             desc: 'Display usage information'
-        method_option :show_methods, aliases: '-m', type: :boolean, default: true,
-                                     desc: 'Display Faker constants with methods'
-        method_option :verbose, aliases: '-v', type: :boolean,
-                                desc: 'Include sample Faker output'
-        def list(*)
-          if options[:help]
-            invoke :help, ['list']
-          else
-            Faker::Bot::Commands::List.new(options).execute
-          end
-        end
+      desc 'version', 'Faker version'
+      def version
+        puts "v#{Faker::Bot::VERSION}"
+      end
+      map %w[--version -v] => :version
 
-        desc 'search [Faker]', 'Search Faker method(s)'
-        method_option :help, aliases: '-h', type: :boolean,
-                             desc: 'Display usage information'
-        method_option :show_methods, aliases: '-m', type: :boolean, default: true,
-                                     desc: 'Display Faker constants with methods'
-        method_option :verbose, aliases: '-v', type: :boolean,
-                                desc: 'Include sample Faker output'
-        def search(query)
-          if options[:help]
-            invoke :help, ['search']
-          else
-            Faker::Bot::Commands::Search.new(options).execute(query)
-          end
+      desc 'list', 'List all Faker constants'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      method_option :show_methods, aliases: '-m', type: :boolean, default: true,
+                                   desc: 'Display Faker constants with methods'
+      method_option :verbose, aliases: '-v', type: :boolean,
+                              desc: 'Include sample Faker output'
+      def list(*)
+        if options[:help]
+          invoke :help, ['list']
+        else
+          Faker::Bot::Commands::List.new(options).execute
+        end
+      end
+
+      desc 'search [Faker]', 'Search Faker method(s)'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      method_option :show_methods, aliases: '-m', type: :boolean, default: true,
+                                   desc: 'Display Faker constants with methods'
+      method_option :verbose, aliases: '-v', type: :boolean,
+                              desc: 'Include sample Faker output'
+      def search(query)
+        if options[:help]
+          invoke :help, ['search']
+        else
+          Faker::Bot::Commands::Search.new(options).execute(query)
         end
       end
     end

--- a/lib/faker/bot/reflector.rb
+++ b/lib/faker/bot/reflector.rb
@@ -11,6 +11,9 @@ module Faker
     #
     class Reflector
       Faker::Base.class_eval do
+        # Skip default deprecation warning output; the CLI will display that.
+        Gem::Deprecate.skip = true
+
         # Select `Faker` subclasses
         # @return [Array] `Faker::Base` sub classes
         def self.descendants


### PR DESCRIPTION
## Description

Since `Faker::Bot::Base` no longer runs "natively" in the `Faker` gem context, the [fix we previously had](https://github.com/stympy/faker/pull/1507/commits/491b63aede1647f039e686f3608a46140b5134a1) to skip deprecation warnings at CLI runtime no longer works. 😭 

However, since the bot operates outside of faker, we can disable the deprecation warnings via `class_eval`_ing_ into `Faker::Base` at runtime. 🙂 

### Background #19 