### PR TITLE
Allow search to accept namespaces and partial matches

### DIFF
--- a/lib/faker/bot/reflectors/search.rb
+++ b/lib/faker/bot/reflectors/search.rb
@@ -16,7 +16,7 @@ module Faker
         end
 
         def initialize(query)
-          @query = query
+          @query = query.downcase
 
           super
         end
@@ -31,14 +31,20 @@ module Faker
         def search_descendants_matching_query
           faker_descendants.each do |descendant|
             methods = descendant.my_singleton_methods
-            matching = methods.select { |method| query_matches?(method.to_s) }
-            store(descendant, matching)
+            if query_matches_class_name?(descendant.to_s)
+              store(descendant, methods)
+            else
+              store(descendant, methods.select { |method| query_matches_method?(method.to_s) })
+            end
           end
         end
 
-        def query_matches?(method_name)
-          method_name_parts = method_name.split(/_/).reject(&:empty?)
-          query.match(/#{method_name_parts.join('|')}/)
+        def query_matches_method?(method_name)
+          method_name.match(/#{query}/)
+        end
+
+        def query_matches_class_name?(class_name)
+          class_name.downcase.match(/#{query}/)
         end
       end
     end

--- a/spec/faker/bot/reflectors/search_spec.rb
+++ b/spec/faker/bot/reflectors/search_spec.rb
@@ -4,25 +4,48 @@ require 'spec_helper'
 
 RSpec.describe Faker::Bot::Reflectors::Search do
   describe '#call' do
-    context 'when a match is found' do
+    let(:result) { described_class.new(query).call }
+
+    context 'when passing a full method name' do
+      let(:query) { 'first_name' }
+
       it 'it returns the list of matches' do
-        query = 'firstname'
-
-        reflector = described_class.new(query)
-        result = reflector.call
-
         expect(result[Faker::Name]).to include(:first_name)
         expect(result).to be_a(Hash)
       end
     end
 
+    context 'when passing a partial method name' do
+      let(:query) { 'fir' }
+
+      it 'returns the list of matches' do
+        expect(result[Faker::Name]).to include(:first_name)
+        expect(result).to be_a(Hash)
+      end
+    end
+
+    context 'when passing a full class name' do
+      let(:query) { 'Beer' }
+
+      it 'returns the list of matches' do
+        expect(result).to include(Faker::Beer)
+        expect(result).to be_a(Hash)
+      end
+    end
+
+    context 'when passing a partial class name' do
+      let(:query) { 'bee' }
+
+      it 'returns the list of matches' do
+        expect(result).to include(Faker::Beer)
+        expect(result).to be_a(Hash)
+      end
+    end
+
     context 'when no match is found' do
+      let(:query) { 'firstname'}
+
       it 'returns an empty hash' do
-        query = 'foobar'
-
-        reflector = described_class.new(query)
-        result = reflector.call
-
         expect(result).to be_empty
         expect(result).to be_a(Hash)
       end


### PR DESCRIPTION
This PR addresses the search features requested in https://github.com/faker-ruby/faker-bot/issues/36. 

New features:
- search by namespace supports the full class name, namespace, lowercase namespace and partial namespace
![Screen Shot 2019-07-25 at 2 25 58 PM](https://user-images.githubusercontent.com/3621638/61909967-408ae180-aee8-11e9-8096-9f654df48b61.png)
- search by method name supports full method searches when the method includes `_` and partial searches
![Screen Shot 2019-07-25 at 2 28 11 PM](https://user-images.githubusercontent.com/3621638/61910064-7760f780-aee8-11e9-8e17-e8df1bc650d3.png)
- we also avoid the unintentional `Faker::Kpop` `i_groups` match when searching `simpsons`
![Screen Shot 2019-07-25 at 2 35 50 PM](https://user-images.githubusercontent.com/3621638/61910436-8b592900-aee9-11e9-92f9-84cec17be654.png)


If the class name matches, we'll return all of the class methods.
If the class name does not match, we'll check to see if any of the methods match.

Let me know any feedback, especially on the spec style 😄 
