### PR TITLE
Specify Codeclimate rubocop channel for ruby 2.6.4 support

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -11,6 +11,7 @@ plugins:
     enabled: true
   rubocop:
     enabled: true
+    channel: rubocop-0-74
 exclude_patterns:
   - "spec/"
   - "vendor/"


### PR DESCRIPTION
### Description

At the moment, codeclimate is using `rubocop-0.52.1` in its build
process which supports the following ruby versions: 2.1, 2.2, 2.3, 2.4, 2.5

In that regard, we can specify the latest rubocop channel 0-74 at
present that supports ruby 2.6.4

Closes #66

Ref: https://docs.codeclimate.com/docs/rubocop