### PR TITLE
Drop support for Ruby 2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
       fail-fast: false # don't fail all matrix builds if one fails
       matrix:
         ruby:
-          - '2.4'
           - '2.5'
           - '2.6'
           - '2.7'


### PR DESCRIPTION
Since faker `2.13.0` dropped the support to Ruby `2.4`, this PR proposes to remove `2.4` from the ruby matrix in the workflow CI file.

Associated PR: https://github.com/faker-ruby/faker-bot/pull/110